### PR TITLE
Issue 01 privilege escalation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
    - Initial commit of prototype tested on Debian 10.
  - 1.0.1
    - Fixed some potential memory leaks, linted, and adjusted documentation.
+ - 1.1.0
+   - Fixed privilege escalation vulnerability that could allow an unprivileged user to run commands as root.

--- a/src/util.c
+++ b/src/util.c
@@ -91,13 +91,6 @@ char *get_local_config_dir(const char *user_name)
     memcpy(config_dir + strlen(home_dir), LOCAL_CONFIG_DIR_SUFFIX, strlen(LOCAL_CONFIG_DIR_SUFFIX));
     config_dir[final_path_len - 1] = 0;
 
-    // Output the hash
-    for (size_t i = 0; i <= strlen(config_dir); i++)
-    {
-        syslog(LOG_INFO, "%02X", config_dir[i]);
-    }
-    syslog(LOG_INFO, "\n");
-
     return config_dir;
 }
 

--- a/src/version.h
+++ b/src/version.h
@@ -2,7 +2,7 @@
 #define SOURCE_VERSION_H
 
 #define VERS_MAJOR 1
-#define VERS_MINOR 0
-#define VERS_REVISION 1
+#define VERS_MINOR 1
+#define VERS_REVISION 0
 
 #endif


### PR DESCRIPTION
Issue resolved and tested as follows by putting a whoami script in /etc/duress.d under root ownership/execution permissions and another in ~/.duress. Addtionally a script that just echo'd "don't run me" was also put under ~/.duress but was given root ownership/execution permissions. Running `sudo pam_test nuvious` on the dev machine produced the following output:

![image](https://user-images.githubusercontent.com/5287736/130333806-34531e82-9786-4d74-87af-11036738e16e.png)
 
The first whoami is run under /etc/duress.d and outputs root as expected. The whoami script under ~/.duress now outputs 'nuvious' instead of 'root' as is desired and required for resolution of this issue. Finally the don't run script under ~/.duress is not run.