### PR TITLE
Add macOS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # Files generated during compilation
 *.o
-pam_test
-duress_sign
+/bin
 
 # Files which may be generated when initially testing generate files.
 *.sha256

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
    - Initial commit of prototype tested on Debian 10.
  - 1.0.1
    - Fixed some potential memory leaks, linted, and adjusted documentation.
+ - 1.1.0
+   - OSX support and makefile improvements contributed by [cormacrelf](https://github.com/cormacrelf).

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,29 @@ SRC_DIR := src
 CC := gcc
 CPP := g++
 CFLAGS := -fPIC -fno-stack-protector
-LDLIB := -lssl -lcrypto -lpam -lpam_misc -lc
-PAM_DIR := /lib/security
-BIN_INSTALL := /usr/bin
+
+OS := $(shell uname)
+ifeq ($(OS),Darwin)
+	# for M1 machines with Rosetta homebrew in /opt
+	PKG_CONFIG_PATH = "$(shell echo $PKG_CONFIG_PATH):/opt/homebrew/opt/openssl/lib/pkgconfig"
+	PC_LIBS := $(shell env PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --libs openssl)
+	PC_INCLUDES := $(shell env PKG_CONFIG_PATH="$(PKG_CONFIG_PATH)" pkg-config --cflags openssl)
+	SDK_PATH := /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk
+	SDK_LIBS := -L$(SDK_PATH) -lSystem
+	LDLIB := -lpam -lSystem -L$(SDK_PATH)/usr/lib $(PC_LIBS)
+	LDINCLUDE := -I$(SDK_PATH)/usr/include $(PC_INCLUDES)
+	LDFLAGS := -x -dylib
+	# otherwise stdlib.h has hundreds of warnings...
+	CFLAGS := $(CFLAGS) -Wno-nullability-completeness -Wno-pointer-sign
+	PAM_DIR := /usr/local/lib/pam
+else
+	LDLIB := -lpam -lpam_misc -lssl -lcrypto
+	LDINCLUDE := $(LDLIB)
+	LDFLAGS := -x -shared
+	PAM_DIR := /lib/security
+endif
+
+BIN_INSTALL := /usr/local/bin
 
 SRCS = $(wildcard $(SRC_DIR)/*.c)
 OBJS = $(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SRCS))
@@ -22,14 +42,14 @@ install: $(BIN_DIR)/pam_duress.so $(BIN_DIR)/duress_sign $(BIN_DIR)/pam_test
 
 $(OBJS): $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	mkdir -p $(OBJ_DIR)
-	$(CC) $(CFLAGS) -c $< $(LDLIB) -o $@
+	$(CC) $(CFLAGS) -c $< $(LDINCLUDE) -o $@
 
 $(BIN_DIR)/duress_sign: $(OBJS)
 	mkdir -p $(BIN_DIR)
 	$(CC) -o $@ $(OBJ_DIR)/duress_sign.o $(OBJ_DIR)/util.o $(LDLIB)
 
 $(BIN_DIR)/pam_duress.so:  $(OBJS)
-	ld -x --shared -o $@ $(OBJ_DIR)/duress.o $(OBJ_DIR)/util.o $(LDLIB)
+	ld $(LDFLAGS) -o $@ $(OBJ_DIR)/duress.o $(OBJ_DIR)/util.o $(LDLIB)
 
 $(BIN_DIR)/pam_test:
 	mkdir -p $(BIN_DIR)

--- a/Makefile
+++ b/Makefile
@@ -20,15 +20,18 @@ install: $(BIN_DIR)/pam_duress.o $(BIN_DIR)/duress_sign $(BIN_DIR)/pam_test
 	cp $(BIN_DIR)/pam_test $(BIN_INSTALL)/
 
 $(OBJS): $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
+	mkdir -p $(OBJ_DIR)
 	$(CC) $(CFLAGS) -c $< $(LDLIB) -o $@
 
 duress_sign: $(OBJS)
+	mkdir -p $(BIN_DIR)
 	$(CC) -o $(BIN_DIR)/duress_sign $(OBJ_DIR)/duress_sign.o $(OBJ_DIR)/util.o $(LDLIB)
 
 pam_duress.o:  $(OBJS)
 	ld -x --shared -o $(BIN_DIR)/pam_duress.o $(OBJ_DIR)/duress.o $(OBJ_DIR)/util.o $(LDLIB)
 
 pam_test:
+	mkdir -p $(BIN_DIR)
 	$(CPP) -o $(BIN_DIR)/pam_test src/pam_test.c $(LDLIB)
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,12 @@ BIN_INSTALL := /usr/bin
 SRCS = $(wildcard $(SRC_DIR)/*.c)
 OBJS = $(patsubst $(SRC_DIR)/%.c, $(OBJ_DIR)/%.o, $(SRCS))
 
-all: $(OBJS) duress_sign pam_test pam_duress.o
+.PHONY: all
+all: $(OBJS) $(BIN_DIR)/duress_sign $(BIN_DIR)/pam_test $(BIN_DIR)/pam_duress.so
 
-install: $(BIN_DIR)/pam_duress.o $(BIN_DIR)/duress_sign $(BIN_DIR)/pam_test
+install: $(BIN_DIR)/pam_duress.so $(BIN_DIR)/duress_sign $(BIN_DIR)/pam_test
 	mkdir -p $(PAM_DIR)
-	cp $(BIN_DIR)/pam_duress.o $(PAM_DIR)/
+	cp $(BIN_DIR)/pam_duress.so $(PAM_DIR)/
 	cp $(BIN_DIR)/duress_sign $(BIN_INSTALL)/
 	cp $(BIN_DIR)/pam_test $(BIN_INSTALL)/
 
@@ -23,24 +24,24 @@ $(OBJS): $(OBJ_DIR)/%.o : $(SRC_DIR)/%.c
 	mkdir -p $(OBJ_DIR)
 	$(CC) $(CFLAGS) -c $< $(LDLIB) -o $@
 
-duress_sign: $(OBJS)
+$(BIN_DIR)/duress_sign: $(OBJS)
 	mkdir -p $(BIN_DIR)
-	$(CC) -o $(BIN_DIR)/duress_sign $(OBJ_DIR)/duress_sign.o $(OBJ_DIR)/util.o $(LDLIB)
+	$(CC) -o $@ $(OBJ_DIR)/duress_sign.o $(OBJ_DIR)/util.o $(LDLIB)
 
-pam_duress.o:  $(OBJS)
-	ld -x --shared -o $(BIN_DIR)/pam_duress.o $(OBJ_DIR)/duress.o $(OBJ_DIR)/util.o $(LDLIB)
+$(BIN_DIR)/pam_duress.so:  $(OBJS)
+	ld -x --shared -o $@ $(OBJ_DIR)/duress.o $(OBJ_DIR)/util.o $(LDLIB)
 
-pam_test:
+$(BIN_DIR)/pam_test:
 	mkdir -p $(BIN_DIR)
-	$(CPP) -o $(BIN_DIR)/pam_test src/pam_test.c $(LDLIB)
+	$(CC) -o $@ src/pam_test.c $(LDLIB)
 
+.PHONY: uninstall
 uninstall:
-	rm -rf $(PAM_DIR)/pam_duress.o
+	rm -rf $(PAM_DIR)/pam_duress.so
 	rm -rf $(BIN_INSTALL)/duress_sign
 	rm -rf $(BIN_INSTALL)/pam_test
 
 .PHONY: clean
-
 clean:
 	rm -rf $(OBJ_DIR)/*.o
 	rm -rf $(BIN_DIR)/*

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifeq ($(OS),Darwin)
 	CFLAGS := $(CFLAGS) -Wno-nullability-completeness -Wno-pointer-sign
 	PAM_DIR := /usr/local/lib/pam
 else
-	LDLIB := -lpam -lpam_misc -lssl -lcrypto
+	LDLIB := -lpam -lpam_misc -lssl -lcrypto -lc
 	LDINCLUDE := $(LDLIB)
 	LDFLAGS := -x -shared
 	PAM_DIR := /lib/security

--- a/src/duress_sign.c
+++ b/src/duress_sign.c
@@ -42,7 +42,7 @@ int main(int argc, const char *argv[])
                 free(file_bytes);
                 return EINVAL;
             }
-            printf("Reading %s, %d...\n", argv[1], st.st_size);
+            printf("Reading %s, %lld...\n", argv[1], st.st_size);
             fread(file_bytes, 1, st.st_size, fileptr);
             printf("Done\n");
             fclose(fileptr);

--- a/src/pam_test.c
+++ b/src/pam_test.c
@@ -1,10 +1,20 @@
 #include <security/pam_appl.h>
+
+/* macOS uses openpam. https://stackoverflow.com/a/66853251 */
+#ifdef   OPENPAM
+#include <security/openpam.h>
+#define  USE_CONV_FUNC  openpam_ttyconv
+#else
 #include <security/pam_misc.h>
+#define  USE_CONV_FUNC  misc_conv
+#endif
+
+#include <stdlib.h>
 #include <stdio.h>
 #include "version.h"
 
 const struct pam_conv conv = {
-	misc_conv,
+	USE_CONV_FUNC,
 	NULL};
 
 int main(int argc, char *argv[])

--- a/src/version.h
+++ b/src/version.h
@@ -2,7 +2,7 @@
 #define SOURCE_VERSION_H
 
 #define VERS_MAJOR 1
-#define VERS_MINOR 0
-#define VERS_REVISION 1
+#define VERS_MINOR 1
+#define VERS_REVISION 0
 
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -3,6 +3,6 @@
 
 #define VERS_MAJOR 1
 #define VERS_MINOR 1
-#define VERS_REVISION 0
+#define VERS_REVISION 1
 
 #endif


### PR DESCRIPTION
Fixes #5 

As noted there, there is a bug where you can get a SIGSEGV when using this with `sudo` and hitting Ctrl-C. I don't know if this is macOS specific.

Needs documentation but basically add this to some /etc/pam.d file.

```
# sudo: auth account password session
auth       sufficient     pam_smartcard.so
auth       required       pam_opendirectory.so
# add this line here
auth       optional       pam_duress.so
account    required       pam_permit.so
password   required       pam_deny.so
session    required       pam_permit.so
```

The installer will copy the PAM module to `/usr/local/lib/pam` because `/usr/lib/pam` is not writable even with sudo with SIP enabled. I think that's what's happening anyway.

Includes a couple of incidental changes which I think are appropriate anyway:

* Changes the binary installation path to `/usr/local/bin`
* Various makefile improvements
* Renames `pam_duress.o` to `pam_duress.so`
* A format warning zapped