### PR TITLE
[#35] Update Documentation example to indicate #!/bin/sh in hello.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ It is easy to do a quick test to ensure the duress module is working properly.
 
 ```bash
 $> mkdir -p ~/.duress
-$> echo 'echo "Hello World"' > ~/.duress/hello.sh
+$> echo -e '#!/bin/sh\necho "Hello World"' > ~/.duress/hello.sh
 $> duress_sign ~/.duress/hello.sh
 Password: # Enter a duress password that is NOT your actual password.
 Confirm: 


### PR DESCRIPTION
**Summary:**  Specified `hello.sh` is a shell script in the content of the script so that the system will execute as a shell script rather than an executable 
**Issue:** #35 
**Tested changes:**
```
$ sudo pam_test $USER
Credentials accepted.
Password: 
Hello World
Account is valid.
Authenticated
```
**Context:** Ran a fresh install of Ubuntu 22.04 and encountered an error where shell script was not running based on following the examples in the documentation. Wrote a simple script to verify the behavior and realized I needed to added `#!/bin/sh` to resolve `exec format` error