### PR TITLE
[#34] Clean memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ It is easy to do a quick test to ensure the duress module is working properly.
 
 ```bash
 $> mkdir -p ~/.duress
-$> echo 'echo "Hello World"' > ~/.duress/hello.sh
+$> echo -e '#!/bin/sh\necho "Hello World"' > ~/.duress/hello.sh
 $> duress_sign ~/.duress/hello.sh
 Password: # Enter a duress password that is NOT your actual password.
 Confirm: 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ It is easy to do a quick test to ensure the duress module is working properly.
 
 ```bash
 $> mkdir -p ~/.duress
-$> echo -e '#!/bin/sh\necho "Hello World"' > ~/.duress/hello.sh
+$> echo 'echo "Hello World"' > ~/.duress/hello.sh
 $> duress_sign ~/.duress/hello.sh
 Password: # Enter a duress password that is NOT your actual password.
 Confirm: 

--- a/src/duress.c
+++ b/src/duress.c
@@ -200,7 +200,8 @@ int execute_duress_scripts(const char *pam_user, const char *pam_pass) {
   // Run user level first
   int local_duress_run = 0;
   char *local_config_dir = get_local_config_dir(pam_user);
-  if (local_config_dir != NULL) {
+  if (local_config_dir != NULL) 
+  {
     local_duress_run = process_dir(local_config_dir, pam_user, pam_pass, pam_user);
     free(local_config_dir);
   }

--- a/src/duress_sign.c
+++ b/src/duress_sign.c
@@ -7,68 +7,72 @@ int main(int argc, const char *argv[])
         printf("Usage:\n\tduress_sign [FILENAME]\n");
         return EINVAL;
     }
-    else
+
+    /* Get the password and copy it to a separate buffer.
+       get_pass uses a single buffer so calling it twice
+       in a row will just return the same buffer which will then
+       hold the second password entered in the confirmation,
+       resulting in the strcmp always returning 0 */
+    char *p = getpass("Password: ");
+    char *password = malloc(strlen(p) + 1);
+    memccpy(password, p, 1, strlen(p) + 1);
+
+    /* Confirm the password */
+    char *confirm = getpass("Confirm: ");
+
+    /* Compare the password */
+    if (strcmp(password, confirm) != 0)
     {
-        /* Get the password and copy it to a separate buffer.
-           get_pass uses a single buffer so calling it twice
-           in a row will just return the same buffer which will then
-           hold the second password entered in the confirmation,
-           resulting in the strcmp always returning 0 */
-        char *p = getpass("Password: ");
-        char *password = malloc(strlen(p) + 1);
-        memccpy(password, p, 1, strlen(p) + 1);
-
-        /* Confirm the password */
-        char *confirm = getpass("Confirm: ");
-
-        /* Compare the password */
-        if (strcmp(password, confirm) != 0)
-        {
-            printf("Password did not match. Aborting.\n");
-            return EINVAL;
-        }
-        else
-        {
-            /* Read in the file to be signed */
-            struct stat st;
-            if (stat(argv[1], &st) == -1)
-                return EINVAL;
-            unsigned char *file_bytes = malloc(st.st_size);
-            FILE *fileptr;
-            fileptr = fopen(argv[1], "rb");
-            if (fileptr == NULL)
-            {
-                printf("Error opening file %s.", argv[1]);
-                free(file_bytes);
-                return EINVAL;
-            }
-            printf("Reading %s, %ld...\n", argv[1], st.st_size);
-            fread(file_bytes, 1, st.st_size, fileptr);
-            printf("Done\n");
-            fclose(fileptr);
-
-            /* Use the file as the salt for the password hash */
-            unsigned char *hash = sha_256_sum(password, strlen(password), file_bytes, st.st_size);
-
-            /* Don't need the file bytes anymore so clean those up */
-            free(file_bytes);
-
-            /* Output the hash */
-            for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
-            {
-                printf("%02X", hash[i]);
-            }
-            printf("\n");
-
-            /* Write the hash to [FILE].sha256 */
-            write_file_hash(argv[1], hash);
-
-            /* Free up the hash allocation */
-            free(hash);
-        }
-
-        /* Free up the password allocation */
+        printf("Password did not match. Aborting.\n");
         free(password);
-        return 0;
+        return EINVAL;
     }
+
+    /* Read in the file to be signed */
+    struct stat st;
+    if (stat(argv[1], &st) == -1) 
+    {
+        free(password);
+        return EINVAL;
+    }
+
+    unsigned char *file_bytes = malloc(st.st_size);
+    FILE *fileptr;
+    fileptr = fopen(argv[1], "rb");
+    if (fileptr == NULL)
+    {
+        printf("Error opening file %s.", argv[1]);
+        free(password);
+        free(file_bytes);
+        return EINVAL;
+    }
+
+    printf("Reading %s, %ld...\n", argv[1], st.st_size);
+    fread(file_bytes, 1, st.st_size, fileptr);
+    printf("Done\n");
+    fclose(fileptr);
+
+    /* Use the file as the salt for the password hash */
+    unsigned char *hash = sha_256_sum(password, strlen(password), file_bytes, st.st_size);
+
+    /* Don't need the file bytes anymore so clean those up */
+    free(file_bytes);
+
+    /* Output the hash */
+    for (int i = 0; i < SHA256_DIGEST_LENGTH; i++)
+    {
+        printf("%02X", hash[i]);
+    }
+    printf("\n");
+
+    /* Write the hash to [FILE].sha256 */
+    write_file_hash(argv[1], hash);
+
+    /* Free up the hash allocation */
+    free(hash);
+    
+
+    /* Free up the password allocation */
+    free(password);
+    return 0;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -14,6 +14,11 @@ char *get_hash_filename(const char *filepath)
 {
     size_t hash_filename_len = strlen(filepath) + strlen(SIGNATURE_EXTENSION);
     char *hash_filename = malloc(hash_filename_len + 1);
+    if (hash_filename == NULL) 
+    {
+        syslog(LOG_INFO, "Failed to allocate buffer for hash_filename.\n");
+        return NULL;
+    }
     memcpy(hash_filename, filepath, strlen(filepath));
     memcpy(hash_filename + strlen(filepath), SIGNATURE_EXTENSION, strlen(SIGNATURE_EXTENSION));
     hash_filename[hash_filename_len] = 0;
@@ -54,6 +59,11 @@ char *get_full_path(const char *directory, const char *filename)
 {
     size_t len = strlen(directory) + strlen(filename) + 2;
     char *fp = malloc(len);
+    if (fp == NULL)
+    {
+        syslog(LOG_INFO, "Failed to allocate buffer for full pathname.\n");
+        return NULL;
+    }
     memcpy(fp, directory, strlen(directory));
     fp[strlen(directory)] = '/';
     memcpy(fp + strlen(directory) + 1, filename, strlen(filename));
@@ -90,6 +100,13 @@ char *get_local_config_dir(const char *user_name)
     const char *home_dir = pwd->pw_dir; 
     size_t final_path_len = strlen(home_dir) + strlen(LOCAL_CONFIG_DIR_SUFFIX) + 1;
     char *config_dir = malloc(final_path_len); // + 1 for null at the end and additional '/' character.
+    if (config_dir == NULL) 
+    {
+        syslog(LOG_INFO, "Failed to allocate buffer for config_dir.\n");
+        free(pwd);
+        free(buffer);
+        return NULL;
+    }
     memcpy(config_dir, home_dir, strlen(home_dir));
     memcpy(config_dir + strlen(home_dir), LOCAL_CONFIG_DIR_SUFFIX, strlen(LOCAL_CONFIG_DIR_SUFFIX));
     config_dir[final_path_len - 1] = 0;
@@ -103,7 +120,18 @@ unsigned char *sha_256_sum(const char *payload, size_t payload_size, const unsig
     unsigned char salt_hash[SHA256_DIGEST_LENGTH];
     SHA256(salt, salt_size, salt_hash);
     unsigned char *payload_hash = malloc(SHA256_DIGEST_LENGTH);
+    if (payload_hash == NULL) 
+    {
+        syslog(LOG_INFO, "Failed to allocate buffer for payload_hash.\n");
+        return NULL;
+    }
     unsigned char *salted_pass = malloc(SHA256_DIGEST_LENGTH + payload_size);
+    if (salted_pass == NULL) 
+    {
+        syslog(LOG_INFO, "Failed to allocate buffer for salted_pass.\n");
+        free(payload_hash);
+        return NULL;
+    }
     memcpy(salted_pass, salt_hash, SHA256_DIGEST_LENGTH);
     memcpy(salted_pass + SHA256_DIGEST_LENGTH, payload, payload_size);
     SHA256(salted_pass, SHA256_DIGEST_LENGTH + payload_size, payload_hash);


### PR DESCRIPTION
**Summary:** There are some memory leaks in the code that have been squashed and some additional checks are written to handle if `malloc` fails.
**Issue:** #34 
**Test:**
```
$ pam_test $USER
Credentials accepted.
Password: 
Hello World
Account is valid.
Authenticated
```
**Valgrind Results:**
```
$ 2>&1 valgrind pam_test $USER > /dev/null | tail -n 14 | head -n 9
==44655== HEAP SUMMARY:
==44655==     in use at exit: 5,089 bytes in 15 blocks
==44655==   total heap usage: 5,716 allocs, 5,701 frees, 1,261,870 bytes allocated
==44655== 
==44655== LEAK SUMMARY:
==44655==    definitely lost: 0 bytes in 0 blocks
==44655==    indirectly lost: 0 bytes in 0 blocks
==44655==      possibly lost: 0 bytes in 0 blocks
==44655==    still reachable: 5,089 bytes in 15 blocks
```