### PR TITLE
Add fallback size on _SC_GETPW_R_SIZE_MAX

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -71,6 +71,14 @@ char *get_full_path(const char *directory, const char *filename)
     return fp;
 }
 
+static size_t get_getpw_r_size_max(void)
+{
+    long sc = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (sc < 0)
+        return 1024;
+    return sc;
+}
+
 char *get_local_config_dir(const char *user_name)
 {
     struct passwd *pwd = (struct passwd *) calloc(1, sizeof(struct passwd));
@@ -79,7 +87,7 @@ char *get_local_config_dir(const char *user_name)
         syslog(LOG_INFO, "Failed to allocate struct passwd for getpwnam_r.\n");
         return NULL;
     }
-    size_t buffer_len = sysconf(_SC_GETPW_R_SIZE_MAX) * sizeof(char);
+    size_t buffer_len = get_getpw_r_size_max() * sizeof(char);
     char *buffer = malloc(buffer_len);
     if (buffer == NULL)
     {

--- a/src/util.c
+++ b/src/util.c
@@ -95,10 +95,10 @@ char *get_local_config_dir(const char *user_name)
         free(pwd);
         return NULL;
     }
-    getpwnam_r(user_name, pwd, buffer, buffer_len, &pwd);
-    if (pwd == NULL)
+    int status = getpwnam_r(user_name, pwd, buffer, buffer_len, &pwd);
+    if (status || pwd == NULL)
     {
-        syslog(LOG_INFO, "getpwnam_r failed to find requested entry.\n");
+        syslog(LOG_INFO, "getpwnam_r failed to find requested entry: %d.\n", status);
         free(buffer);
         free(pwd);
         return NULL;


### PR DESCRIPTION
sysconf(_SC_GETPW_R_SIZE_MAX) is allowed by POSIX to return -1 on success if the limit is unbounded. Direct conversion to size_t would result in an extremely large, unallocatable size and a UB at the same time. Let's just use a sensible default instead.

The changed code still has a potential UB if for some reason `long` is larger than `SIZE_MAX`. Not that I'm aware of any such architecture.

`sizeof(char)` is pretty useless but also harmless, so I didn't touch it.

Should fix #7.