### PR TITLE
Use --needed parameter on pacman

### DIFF
--- a/docs/ArchLinux.md
+++ b/docs/ArchLinux.md
@@ -13,7 +13,7 @@ so your dependencies look more like the below:
 
 ```bash
 sudo pacman -Su
-sudo pacman -S base-devel openssl
+sudo pacman --needed -S base-devel openssl
 ```
 
 ### Build and Install


### PR DESCRIPTION
From pacman(8) manual page:

       --needed
           Do not reinstall the targets that are already up-to-date.

I think it makes sense to add this, so user doesn't re-install packages