### PR TITLE
Added initial documentation for Red Hat variant support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Files which may be generated when initially testing generate files.
 *.sha256
+
+# VS Code
+.vscode

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ welcome contributions from the community. Below are specific linux variant
 installation guides available:
 
 - [Arch Linux](docs/ArchLinux.md)
+- [Red Hat Family of Linux](docs/RHLinux.md)
 
 ## Demo
 

--- a/docs/RHLinux.md
+++ b/docs/RHLinux.md
@@ -1,0 +1,77 @@
+# Pam Duress on Red Hat variants
+
+This is a guide on how to use pam duress on Red Hat linux in support of
+[Issue 51](https://github.com/nuvious/pam-duress/issues/51) on GitHub
+submitted by [radioaddition](https://github.com/radioaddition).
+
+## Installation 
+
+### Dependencies
+
+For the dependencies arch packages the development libraries with openssl
+so your dependencies look more like the below:
+
+```bash
+# Redhat family dependencies
+sudo dnf group install development-tools -y
+sudo dnf install pam-devel -y
+```
+
+### Build and Install
+
+The build and installation steps remain the same.
+
+```bash
+make
+sudo make install
+make clean
+```
+
+## Configuration
+
+Much of the pam configurations all eventually point to /etc/system-auth
+which has many more entries than say a Debian distribution. Below was taken
+from a Fedora Live 41 instance as an example, but your specific RedHat variant
+may be different. In this example, you'll need to modify the configuration as
+follows:
+
+### /etc/pam.d/system-auth
+
+Change system-auth from this:
+
+```bash
+...
+auth       required                    pam_env.so
+auth       required                    pam_faildelay.so delay=2000000
+auth       sufficient                  pam_unix.so nullok
+auth       required                    pam_deny.so
+...
+```
+
+To this:
+
+```bash
+...
+auth       required                    pam_env.so
+auth       required                    pam_faildelay.so delay=2000000
+auth       sufficient                  pam_unix.so nullok
+auth       sufficient                  pam_duress.so
+auth       required                    pam_deny.so
+...
+```
+
+## NOTE: Use ssh instead of pam_test
+
+Though `pam_test` is a part of this repo it doesn't seem to be effective on
+on Arch system; see [Issue 29](https://github.com/nuvious/pam-duress/issues/29).
+
+Instead of using `pam_test` use `ssh USER@localhost`. This will simulate a
+remote login and should trigger the full duress chain.
+
+## Remaining Configuration
+
+All further configurations regarding creation, signing and permissions for
+duress scripts are the same, so continue in the
+[configuration section of the README](../README.md#configuration) to continue
+setting up duress scripts.
+

--- a/docs/RHLinux.md
+++ b/docs/RHLinux.md
@@ -19,11 +19,13 @@ sudo dnf install pam-devel -y
 
 ### Build and Install
 
-The build and installation steps remain the same.
+As noted in [Issue 51](https://github.com/nuvious/pam-duress/issues/51), the
+location of PAM so libraries is in `/usr/lib64/security` in Red Hat variants so
+we simply need to set that in the installation command:
 
 ```bash
 make
-sudo make install
+sudo make install PAM_DIR=/usr/lib64/security
 make clean
 ```
 
@@ -60,13 +62,18 @@ auth       required                    pam_deny.so
 ...
 ```
 
-## NOTE: Use ssh instead of pam_test
+## Testing
 
-Though `pam_test` is a part of this repo it doesn't seem to be effective on
-on Arch system; see [Issue 29](https://github.com/nuvious/pam-duress/issues/29).
+The `pam_test` doesn't work the same in Red Hat variants as it does in debian
+so to test the configuration you'll simply need to run the following:
 
-Instead of using `pam_test` use `ssh USER@localhost`. This will simulate a
-remote login and should trigger the full duress chain.
+```
+sudo su # Drop into a root shell
+login [USERNAME WITH CONFIGURED DURESS]
+```
+
+After login with a configured duress password, you should see the effects of
+your test applied. 
 
 ## Remaining Configuration
 
@@ -74,4 +81,3 @@ All further configurations regarding creation, signing and permissions for
 duress scripts are the same, so continue in the
 [configuration section of the README](../README.md#configuration) to continue
 setting up duress scripts.
-


### PR DESCRIPTION
Done in support of #51. Provides build and configuration guidance. Tested using Fedora 41 live.